### PR TITLE
提出資料監視・メール送信機能を追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ menu = st.sidebar.radio("機能メニュー", [
     "📢 お知らせ作成",
     "📅 活動計画作成",
     "📄 大会資料作成",
+    "📬 提出資料監視",
 ])
 
 # ── 議事録作成 ──────────────────────────
@@ -171,3 +172,198 @@ elif menu == "📄 大会資料作成":
         st.code(out_path)
         st.subheader("生成された内容（プレビュー）")
         st.markdown(updated_text)
+
+# ── 提出資料監視 ────────────────────────
+elif menu == "📬 提出資料監視":
+    st.subheader("提出資料監視・メール送信")
+    st.caption("共有フォルダの新しい資料を自動監視し、提出依頼文を生成します")
+    
+    import json
+    import pdfplumber
+    from docx import Document as DocxDocument
+    from datetime import datetime, timedelta
+    
+    # 監視対象フォルダと出力フォルダのパス
+    MONITOR_FOLDER = Path(r"C:\Users\batte\OneDrive\共有用")
+    OUTPUT_FOLDER = Path(r"C:\Users\batte\OneDrive\少林寺\葛飾区連盟\AI作業フォルダ\提出関連資料")
+    PROCESSED_FILES_JSON = Path("processed_files.json")
+    
+    # 処理済みファイルの記録を読み込み
+    def load_processed_files():
+        try:
+            if PROCESSED_FILES_JSON.exists():
+                with open(PROCESSED_FILES_JSON, 'r', encoding='utf-8') as f:
+                    return json.load(f)
+            return {}
+        except Exception:
+            return {}
+    
+    # 処理済みファイルの記録を保存
+    def save_processed_files(processed_files):
+        try:
+            with open(PROCESSED_FILES_JSON, 'w', encoding='utf-8') as f:
+                json.dump(processed_files, f, ensure_ascii=False, indent=2)
+        except Exception as e:
+            st.error(f"処理済みファイル記録の保存に失敗しました: {e}")
+    
+    # ファイル読み込み関数
+    def read_document(file_path):
+        try:
+            file_path = Path(file_path)
+            if file_path.suffix.lower() == '.pdf':
+                with pdfplumber.open(file_path) as pdf:
+                    text = "\n".join(
+                        page.extract_text() for page in pdf.pages
+                        if page.extract_text()
+                    )
+                return text
+            elif file_path.suffix.lower() in ['.docx', '.doc']:
+                doc = DocxDocument(file_path)
+                text = "\n".join(paragraph.text for paragraph in doc.paragraphs)
+                return text
+            else:
+                return None
+        except Exception as e:
+            st.error(f"ファイル読み込みエラー ({file_path.name}): {e}")
+            return None
+    
+    # ファイル名にプレフィックスを追加して保存
+    def rename_processed_file(file_path):
+        try:
+            file_path = Path(file_path)
+            new_name = f"済_{file_path.name}"
+            new_path = file_path.parent / new_name
+            file_path.rename(new_path)
+            return str(new_path)
+        except Exception as e:
+            st.error(f"ファイル名変更エラー: {e}")
+            return None
+    
+    if st.button("📁 新しい資料をスキャン"):
+        with st.spinner("フォルダをスキャン中..."):
+            try:
+                if not MONITOR_FOLDER.exists():
+                    st.error(f"監視フォルダが見つかりません: {MONITOR_FOLDER}")
+                    st.stop()
+                
+                # 処理済みファイルの記録を読み込み
+                processed_files = load_processed_files()
+                
+                # フォルダ内のファイルをスキャン
+                supported_extensions = {'.pdf', '.docx', '.doc'}
+                new_files = []
+                
+                for file_path in MONITOR_FOLDER.rglob('*'):
+                    if (file_path.is_file() and 
+                        file_path.suffix.lower() in supported_extensions and
+                        not file_path.name.startswith('済_')):
+                        
+                        file_key = str(file_path)
+                        file_mtime = file_path.stat().st_mtime
+                        
+                        # 新しいファイルまたは更新されたファイルを検出
+                        if (file_key not in processed_files or 
+                            processed_files[file_key] != file_mtime):
+                            new_files.append(file_path)
+                
+                if not new_files:
+                    st.info("新しい資料は見つかりませんでした")
+                else:
+                    st.success(f"{len(new_files)}個の新しい資料を発見しました")
+                    
+                    # 各ファイルを処理
+                    for file_path in new_files:
+                        st.subheader(f"📄 {file_path.name}")
+                        
+                        # ファイル内容を読み込み
+                        with st.spinner("ファイルを読み込み中..."):
+                            document_text = read_document(file_path)
+                            
+                        if document_text:
+                            st.info(f"読み込み完了（{len(document_text)}文字）")
+                            
+                            # AIで内容を分析
+                            with st.spinner("AIが内容を分析中..."):
+                                analysis_prompt = f"""以下の資料内容を分析して、以下の情報を抽出してください：
+
+1. 概要（資料の主な内容）
+2. 実施内容（具体的に何をするか）
+3. 提出期限（いつまでに提出が必要か）
+
+【資料内容】
+{document_text[:2000]}
+
+【出力形式】
+概要: （概要を簡潔に）
+実施内容: （実施内容を具体的に）
+提出期限: （期限を明確に、日付がある場合は「YYYY年MM月DD日」形式で）
+"""
+                                
+                                analysis_result = llm.invoke([HumanMessage(content=analysis_prompt)])
+                                analysis_text = analysis_result.content
+                            
+                            st.markdown("### 📊 分析結果")
+                            st.markdown(analysis_text)
+                            
+                            # 依頼文を生成
+                            with st.spinner("依頼文を作成中..."):
+                                request_prompt = f"""以下の分析結果をもとに、葛飾区少林寺拳法連盟のメンバーへの提出依頼文を作成してください。
+
+【分析結果】
+{analysis_text}
+
+【依頼文の要件】
+- 丁寧で分かりやすい文章
+- 概要、実施内容、提出期限を含める
+- 連盟内の提出期限は、資料上の提出期限の10日前に設定する
+- 件名も含める
+
+【出力形式】
+件名: （メールの件名）
+
+（依頼文の本文）
+"""
+                                
+                                request_result = llm.invoke([HumanMessage(content=request_prompt)])
+                                request_text = request_result.content
+                            
+                            st.markdown("### ✉️ 生成された依頼文")
+                            st.markdown(request_text)
+                            
+                            # 依頼文を保存
+                            try:
+                                OUTPUT_FOLDER.mkdir(parents=True, exist_ok=True)
+                                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                                output_filename = f"提出依頼_{file_path.stem}_{timestamp}.txt"
+                                output_path = OUTPUT_FOLDER / output_filename
+                                
+                                with open(output_path, 'w', encoding='utf-8') as f:
+                                    f.write(request_text)
+                                
+                                st.success(f"依頼文を保存しました: {output_filename}")
+                                
+                                # 元ファイルに「済_」プレフィックスを追加
+                                renamed_path = rename_processed_file(file_path)
+                                if renamed_path:
+                                    st.info(f"元ファイルを「済_」付きで保存しました")
+                                
+                                # 処理済みファイルとして記録
+                                processed_files[str(file_path)] = file_path.stat().st_mtime
+                                
+                            except Exception as e:
+                                st.error(f"ファイル保存エラー: {e}")
+                        
+                        else:
+                            st.warning(f"{file_path.name}の読み込みに失敗しました")
+                    
+                    # 処理済みファイル記録を保存
+                    save_processed_files(processed_files)
+                    
+            except Exception as e:
+                st.error(f"スキャン中にエラーが発生しました: {e}")
+    
+    st.markdown("---")
+    st.markdown("### 📝 設定情報")
+    st.info(f"**監視フォルダ:** {MONITOR_FOLDER}")
+    st.info(f"**出力フォルダ:** {OUTPUT_FOLDER}")
+    st.caption("対応形式: PDF (.pdf), Word (.docx, .doc)")


### PR DESCRIPTION
- sidebarメニューに「📬 提出資料監視」を追加
- OneDrive共有フォルダの新しいPDF/Wordファイルを自動検出
- pdfplumber/python-docxでドキュメント読み込み
- Ollama llama3.2で内容分析（概要、実施内容、提出期限）
- 自動的に提出依頼文を生成し保存
- 処理済みファイルに「済_」プレフィックス追加
- 処理済みファイルをJSONで記録し重複処理を防止

🤖 Generated with [Claude Code](https://claude.ai/code)